### PR TITLE
Fix sidebar padding on mobile

### DIFF
--- a/sass/css/_sidebar.scss
+++ b/sass/css/_sidebar.scss
@@ -36,7 +36,7 @@
 	}
 
 	> .sidebar-links {
-		padding: 2rem 0;
+		padding: 2rem 0 4.5rem 0;
 
 		> li:not(:first-child) {
 			margin-top: 0.75rem;


### PR DESCRIPTION
You should now be able to scroll down on the sidebar on devices with a small height. The bottom padding for sidebar-links was increased from 2rem to 4.5rem. Closed #5 

![image](https://github.com/Aidoku/Website/assets/25382370/f5958149-81e3-4415-8f3d-00f66cc5ef8c)

